### PR TITLE
rename habits

### DIFF
--- a/src/app/impl_self.rs
+++ b/src/app/impl_self.rs
@@ -50,6 +50,28 @@ impl App {
         }
     }
 
+    // Missing name argument is checked by command.rs.from_string()
+    pub fn rename_by_name(&mut self, og_name: &str, new_name: &str) {
+        let og_pos = self.habits.iter_mut().position(|habit| habit.name() == og_name);
+        if og_pos.is_none()
+        {
+            self.message.set_kind(MessageKind::Error);
+            self.message.set_message(format!("Could not rename habit `{og_name}`: `{og_name}` already exists"));
+            return;
+        }
+
+        let nn_pos = self.habits.iter().position(|habit| habit.name() == new_name);
+        if nn_pos.is_some() {
+            self.message.set_kind(MessageKind::Error);
+            self.message.set_message(format!("Could not rename habit `{og_name}`: `{new_name}` already exists"));
+            return;
+        }
+
+        self.habits[og_pos.unwrap()].rename(new_name);
+        self.message.set_kind(MessageKind::Info);
+        self.message.set_message(format!("`{og_name}` renamed to `{new_name}`"));
+    }
+
     pub fn backfill_by_name(&mut self, name: &str) {
         // If no argument was given, "all" will be the name
         if name == "all" {
@@ -320,10 +342,9 @@ impl App {
                 Command::Quit | Command::Write | Command::WriteAndQuit => self.save_state(),
                 Command::MonthNext => self.sift_forward(),
                 Command::MonthPrev => self.sift_backward(),
-                Command::Blank => {},
-                Command::BackFill(name) => {
-                    self.backfill_by_name(&name);
-                }
+                Command::Blank     => {},
+                Command::BackFill(name) => self.backfill_by_name(&name),
+                Command::Rename(og, new)=> self.rename_by_name(&og, &new),
             },
             Err(e) => {
                 self.message.set_message(e.to_string());

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,6 @@
 use std::fmt;
+use std::fs::File;
+use std::process::exit;
 use std::str::FromStr;
 
 use cursive::event::{Event, EventResult, Key};
@@ -23,7 +25,8 @@ static COMMANDS: &'static [&'static str] = &[
     "write",
     "help",
     "writeandquit",
-    "backfill"
+    "backfill",
+    "rename"
 ];
 
 fn get_command_completion(prefix: &str) -> Option<String> {
@@ -146,7 +149,7 @@ impl FromStr for GoalKind {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Command {
     Add(String, Option<GoalKind>, bool),
     MonthPrev,
@@ -161,6 +164,8 @@ pub enum Command {
     WriteAndQuit,
     // Fill in missing days with "not done"
     BackFill(String),
+    // Rename a habit
+    Rename(String, String)
 }
 
 #[derive(Debug)]
@@ -245,6 +250,16 @@ impl Command {
                 }
                 // Else backfill a specific habit
                 return Ok(Command::BackFill(args[0].to_string()));
+            }
+
+            "rename" | "rn" => {
+                if args.is_empty() {
+                    return Err(CommandLineError::NotEnoughArgs(first, 2));
+                }
+                let og_name  = args[0].to_string();
+                let new_name = args[1].to_string();
+
+                return Ok(Command::Rename(og_name, new_name));
             }
 
             "mprev" | "month-prev" => return Ok(Command::MonthPrev),

--- a/src/habit/bit.rs
+++ b/src/habit/bit.rs
@@ -81,7 +81,6 @@ impl Habit for Bit {
     }
 
     fn backfill(&mut self) {
-        // TODO(tyler): get all dates in stats
         // Loop through them all and if a date is missing,
         // then set it to false
         let dates: Vec<&NaiveDate> = self.stats.keys().collect();
@@ -108,6 +107,10 @@ impl Habit for Bit {
         }
     }
 
+    fn rename(&mut self, new_name: &str) {
+        self.name = String::from(new_name);
+    }
+
     fn reached_goal(&self, date: NaiveDate) -> bool {
         if let Some(val) = self.stats.get(&date) {
             if val.0 >= self.goal.0 {
@@ -118,6 +121,8 @@ impl Habit for Bit {
     }
 
     fn goal_not_reached(&self, date: NaiveDate) -> bool {
+        // Could probably be just
+        // return self.stat.get(&date).is_some();
         if let Some(val) = self.stats.get(&date){
             // return val.0;
             return true;

--- a/src/habit/count.rs
+++ b/src/habit/count.rs
@@ -56,7 +56,10 @@ impl Habit for Count {
         *self.stats.entry(date).or_insert(val) = val;
     }
     fn backfill(&mut self) -> () {
-        todo!();
+        todo!("Backfill is not implemented for `count.rs`");
+    }
+    fn rename(&mut self, new_name: &str) {
+        self.name = String::from(new_name);
     }
     fn reached_goal(&self, date: NaiveDate) -> bool {
         if let Some(val) = self.stats.get(&date) {

--- a/src/habit/float.rs
+++ b/src/habit/float.rs
@@ -130,6 +130,9 @@ impl Habit for Float {
     fn backfill(&mut self) -> () {
         todo!();
     }
+    fn rename(&mut self, new_name: &str) {
+        self.name = String::from(new_name);
+    }
     fn reached_goal(&self, date: NaiveDate) -> bool {
         if let Some(val) = self.stats.get(&date) {
             if val >= &self.goal {

--- a/src/habit/traits.rs
+++ b/src/habit/traits.rs
@@ -24,6 +24,7 @@ pub trait Habit {
     fn set_name(&mut self, name: impl AsRef<str>);
     fn kind(&self) -> GoalKind;
     fn backfill(&mut self) -> ();
+    fn rename(&mut self, new_name: &str);
 
     fn inner_data_ref(&self) -> &InnerData;
     fn inner_data_mut_ref(&mut self) -> &mut InnerData;
@@ -43,6 +44,7 @@ pub trait HabitWrapper: erased_serde::Serialize {
     fn required_size(&mut self, _: Vec2) -> Vec2;
     fn take_focus(&mut self, _: Direction) -> Result<EventResult, CannotFocus>;
     fn backfill(&mut self) -> ();
+    fn rename(&mut self, new_name: &str);
 
     fn inner_data_ref(&self) -> &InnerData;
     fn inner_data_mut_ref(&mut self) -> &mut InnerData;
@@ -86,6 +88,9 @@ macro_rules! auto_habit_impl {
             }
             fn backfill(&mut self) -> () {
                 Habit::backfill(self)
+            }
+            fn rename(&mut self, new_name: &str) {
+                Habit::rename(self, new_name);
             }
             fn inner_data_ref(&self) -> &InnerData {
                 Habit::inner_data_ref(self)


### PR DESCRIPTION
A user can now rename a habit from command mode.

`:rename <og_name> <new_name>`:  Renames habit_a to habit_b
`:rn <og_name> <new_name>`: Same as above

![image](https://github.com/user-attachments/assets/1565f3be-921f-4e72-9d3e-51738dd5032e)
